### PR TITLE
chore(release): bump slurmutils version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "slurmutils"
-version = "0.5.0"
+version = "0.6.0"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 repository = "https://github.com/charmed-hpc/slurmutils"
 authors = ["Jason C. Nucciarone <nuccitheboss@ubuntu.com>"]


### PR DESCRIPTION
Bump the version of slurmutils for 0.6.0.

Release adds the `update` method for merging data model configurations together.