### PR TITLE
chore(release): bump slurmutils version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "slurmutils"
-version = "0.7.0"
+version = "0.8.0"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 repository = "https://github.com/charmed-hpc/slurmutils"
 authors = ["Jason C. Nucciarone <nuccitheboss@ubuntu.com>"]


### PR DESCRIPTION
This PR bumps the version of slurmutils to 0.8.0 with the inclusion of the ability to set file permissions when dumping or editing a Slurm-related configuration file.