### PR TITLE
fix: correctly marshall slurm dict boolean values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "slurmutils"
-version = "0.8.0"
+version = "0.8.1"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 repository = "https://github.com/charmed-hpc/slurmutils"
 authors = ["Jason C. Nucciarone <nuccitheboss@ubuntu.com>"]

--- a/slurmutils/models/callback.py
+++ b/slurmutils/models/callback.py
@@ -64,7 +64,7 @@ def to_slurm_dict(value: Dict[str, Any]) -> str:
     result = []
     for k, v in value.items():
         if isinstance(v, bool) and v:
-            result.append(v)
+            result.append(k)
             continue
 
         result.append(f"{k}={v}")

--- a/tests/unit/editors/test_slurmconfig.py
+++ b/tests/unit/editors/test_slurmconfig.py
@@ -80,6 +80,7 @@ class TestSlurmConfigEditor(TestCase):
             config.max_job_count = 20000
             config.proctrack_type = "proctrack/linuxproc"
             config.plugin_dir.append("/snap/slurm/current/plugins")
+            config.slurmctld_parameters = {"enable_configless": True}
             new_node = Node(NodeName="batch-0", **config.nodes["juju-c9fc6f-2"])
             del config.nodes["juju-c9fc6f-2"]
             config.nodes.update(new_node.dict())
@@ -92,6 +93,7 @@ class TestSlurmConfigEditor(TestCase):
             config.plugin_dir,
             ["/usr/local/lib", "/usr/local/slurm/lib", "/snap/slurm/current/plugins"],
         )
+        self.assertDictEqual(config.slurmctld_parameters, {"enable_configless": True})
         self.assertEqual(config.nodes["batch-0"]["NodeAddr"], "10.152.28.48")
 
         with slurmconfig.edit("/etc/slurm/slurm.conf") as config:


### PR DESCRIPTION
Small PR that fixes the `to_slurm_dict` callback to correctly handle boolean values in Slurm-style dictionaries such as `SlurmctldParameters=enable_configless`.

Fixes #27