### PR TITLE
fix: escape `RebootProgram` with quotes when marshalling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "slurmutils"
-version = "0.8.2"
+version = "0.8.3"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 repository = "https://github.com/charmed-hpc/slurmutils"
 authors = ["Jason C. Nucciarone <nuccitheboss@ubuntu.com>"]

--- a/slurmutils/models/callback.py
+++ b/slurmutils/models/callback.py
@@ -19,7 +19,7 @@ __all__ = [
     "CommaSeparatorCallback",
     "ColonSeparatorCallback",
     "SlurmDictCallback",
-    "ReasonCallback",
+    "QuoteCallback",
 ]
 
 from typing import Any, Callable, Dict, NamedTuple, Optional
@@ -75,4 +75,6 @@ def to_slurm_dict(value: Dict[str, Any]) -> str:
 CommaSeparatorCallback = Callback(lambda v: v.split(","), lambda v: ",".join(v))
 ColonSeparatorCallback = Callback(lambda v: v.split(":"), lambda v: ":".join(v))
 SlurmDictCallback = Callback(from_slurm_dict, to_slurm_dict)
-ReasonCallback = Callback(None, lambda v: f'"{v}"')  # Ensure that 'Reason=...' is quoted properly.
+# Ensure that config values that allow spaces are properly escaped with quotes (")
+# when dumped into a string or file.
+QuoteCallback = Callback(None, lambda v: f'"{v}"')

--- a/slurmutils/models/option.py
+++ b/slurmutils/models/option.py
@@ -32,7 +32,7 @@ from .callback import (
     Callback,
     ColonSeparatorCallback,
     CommaSeparatorCallback,
-    ReasonCallback,
+    QuoteCallback,
     SlurmDictCallback,
 )
 
@@ -276,7 +276,7 @@ class SlurmConfigOptionSet(_OptionSet):
     PropagatePrioProcess: Callback = Callback()
     PropagateResourceLimits: Callback = CommaSeparatorCallback
     PropagateResourceLimitsExcept: Callback = CommaSeparatorCallback
-    RebootProgram: Callback = Callback()
+    RebootProgram: Callback = QuoteCallback
     ReconfigFlags: Callback = Callback()
     KeepPartInfo: Callback = Callback()
     KeepPartState: Callback = Callback()
@@ -382,7 +382,7 @@ class NodeOptionSet(_OptionSet):
     Port: Callback = Callback()
     Procs: Callback = Callback()
     RealMemory: Callback = Callback()
-    Reason: Callback = ReasonCallback
+    Reason: Callback = QuoteCallback
     Sockets: Callback = Callback()
     SocketsPerBoard: Callback = Callback()
     State: Callback = Callback()
@@ -396,7 +396,7 @@ class DownNodeOptionSet(_OptionSet):
     """`slurm.conf` down node configuration options."""
 
     DownNodes: Callback = CommaSeparatorCallback
-    Reason: Callback = ReasonCallback
+    Reason: Callback = QuoteCallback
     State: Callback = Callback()
 
 
@@ -411,7 +411,7 @@ class FrontendNodeOptionSet(_OptionSet):
     DenyGroups: Callback = CommaSeparatorCallback
     DenyUsers: Callback = CommaSeparatorCallback
     Port: Callback = Callback()
-    Reason: Callback = ReasonCallback
+    Reason: Callback = QuoteCallback
     State: Callback = Callback()
 
 

--- a/tests/unit/editors/test_slurmconfig.py
+++ b/tests/unit/editors/test_slurmconfig.py
@@ -77,6 +77,7 @@ class TestSlurmConfigEditor(TestCase):
         # Test descriptors for `slurm.conf` configuration options.
         with slurmconfig.edit("/etc/slurm/slurm.conf") as config:
             del config.inactive_limit
+            config.reboot_program = "systemctl reboot"
             config.max_job_count = 20000
             config.proctrack_type = "proctrack/linuxproc"
             config.plugin_dir.append("/snap/slurm/current/plugins")
@@ -87,6 +88,7 @@ class TestSlurmConfigEditor(TestCase):
 
         config = slurmconfig.load("/etc/slurm/slurm.conf")
         self.assertIsNone(config.inactive_limit)
+        self.assertEqual(config.reboot_program, "systemctl reboot")
         self.assertEqual(config.max_job_count, "20000")
         self.assertEqual(config.proctrack_type, "proctrack/linuxproc")
         self.assertListEqual(


### PR DESCRIPTION
Small PR that fixes #32. Also renames `ReasonCallback` to `QuoteCallback` since the name `ReasonCallback` is too scoped to the `Reason` configuration key that several Slurm configuration objects support.

Bumps `slurmutils` to version 0.8.3.