### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @charmed-hpc/python-reviewers


### PR DESCRIPTION
CODEOWNERS file is configured such that every time a new PR is opened against this repo, two teammates from the `python-reviewers` team will be automatically assigned as PR reviewers. This is will make opening PRs faster for us! 