### PR TITLE
feat: add the `calculate_rs` function to slurmutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ are orchestrating deployments of new and current Slurm clusters. Gone are the da
 seething over incomplete Jinja2 templates. Current utilities shipped in the 
 slurmutils package include:
 
+#### `from slurmutils import ...`
+
+* `calculate_rs`: A function for calculating the ranges and strides of an iterable with
+  unique elements. This function can be used to help convert arrays of node hostnames,
+  device file ids, etc into a Slurm hostname specification.
+
 #### `from slurmutils.editors import ...`
 
 * `acctgatherconfig`: An editor for _acct_gather.conf_ configuration files.
@@ -48,6 +54,40 @@ $ poetry install
 ```
 
 ### Usage
+
+#### `slurmutils`
+
+The top-level provides access to some utilities that streamline common Slurm-related
+operations such as calculating the ranges and strides for a Slurm hostname specification.
+Here's some example operations you can perform with these utilities:
+
+##### `calculate_rs`
+
+###### Calculate a range and/or stride from a list of node hostnames
+
+```python3
+from os.path import commonprefix
+
+from slurmutils import calculate_rs
+
+nodes = ["juju-abc654-1", "juju-abc654-2", "juju-abc654-4"]
+prefix = commonprefix(nodes)
+nums = [int(n.partition(prefix)[2]) for n in nodes]
+slurm_host_spec = prefix + calculate_rs(nums)  # "juju-abc654-[1-2,4]"
+```
+
+###### Calculate a device file range for Nvidia GPUs
+
+```python3
+from pathlib import Path
+
+from slurmutils import calculate_rs
+
+device_files = [file for file in Path("/dev").iterdir() if "nvidia" in file.name]
+prefix = "/dev/nvidia"
+nums = [int(n.partition(prefix)[2]) for n in device_files]
+file_spec = prefix + calculate_rs(nums)  # "/dev/nvidia[0-4]"
+```
 
 #### `slurmutils.editors`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "slurmutils"
-version = "0.11.0"
+version = "0.12.0"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 repository = "https://github.com/charmed-hpc/slurmutils"
 authors = ["Jason C. Nucciarone <nuccitheboss@ubuntu.com>"]

--- a/slurmutils/__init__.py
+++ b/slurmutils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -13,3 +13,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Utilities and APIs for interfacing with the Slurm workload manager."""
+
+from .utils import calculate_rs as calculate_rs

--- a/slurmutils/utils.py
+++ b/slurmutils/utils.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for streamlining common Slurm-related operations."""
+
+__all__ = ["calculate_rs"]
+
+from collections.abc import Iterable
+from itertools import groupby
+
+
+def calculate_rs(elements: Iterable[int]) -> str:
+    """Calculate ranges and strides in an iterable.
+
+    Args:
+        elements: Iterable to calculate ranges and strides in.
+            The iterable's elements must be unique and sortable in ascending order.
+
+    Returns:
+        A square-bracketed string with comma-separated ranges of consecutive values.
+        example_input  = [0,1,2,3,4,5,6,8,9,10,12,14,15,16,18]
+        example_output = '[0-6,8-10,12,14-16,18]'
+
+    Notes:
+        This function can be used to assist with converting arrays of resource names
+        such as device files and node names into the Slurm hostname specification.
+    """
+    elements = sorted(elements)
+
+    # The input is enumerate()-ed to produce a list of tuples of the elements and their indices.
+    # groupby() uses the lambda key function to group these tuples by the difference between the
+    # element and index. Consecutive values have equal difference between element and index,
+    # so are grouped together. Hence, the elements of the first and last members of each
+    # group give the range of consecutive values. If the group has only a single member, there are
+    # no consecutive values either side of it (a "stride").
+    out = "["
+    for _, group in groupby(enumerate(elements), lambda elem: elem[1] - elem[0]):
+        group = list(group)
+
+        if len(group) == 1:
+            # Single member, this is a stride.
+            out += f"{group[0][1]},"
+        else:
+            # Range of consecutive values is first-last in group.
+            out += f"{group[0][1]}-{group[-1][1]},"
+
+    out = out.rstrip(",") + "]"
+    return out

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 3 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for the `utils` module."""
+
+from unittest import TestCase
+
+from slurmutils import calculate_rs
+
+
+class TestUtils(TestCase):
+    """Unit tests for the `utils` module ."""
+
+    def test_calculate_rs(self) -> None:
+        """Test the `calculate_rs` utility function."""
+        node_range = [0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 14, 15, 16, 18]
+        r = calculate_rs(node_range)
+        self.assertEqual(r, "[0-6,8-10,12,14-16,18]")


### PR DESCRIPTION
This PR adds @dsloanm's mega-based `calculate_rs` method to slurmutils so that it can be easily consumed by other charms. I copied it into the `utils` module, but it can be imported through the top-level module:

```python3
from slurmutils import calculate_rs
``` 

I also added some unit tests and documentation for `calculate_rs` so that we have some examples of how it can be used to calculate device file and node name ranges.