### PR TITLE
fix: properly handle `False` booleans in dict callbacks

### DIFF
--- a/slurmutils/core/callback.py
+++ b/slurmutils/core/callback.py
@@ -198,8 +198,11 @@ def _make_dict_callback(sep: str, pair_sep: str = "=", array_sep: str | None = N
         result: list[str] = []
 
         for k, v in value.items():
-            if isinstance(v, bool) and v:
-                result.append(k)
+            if isinstance(v, bool):
+                # If `v` is `False`, omit `k` from final marshaled output.
+                if v:
+                    result.append(k)
+
                 continue
 
             if array_sep is not None and isinstance(v, Iterable) and not isinstance(v, str):

--- a/slurmutils/slurm.py
+++ b/slurmutils/slurm.py
@@ -339,7 +339,9 @@ class SlurmConfig(Model):
     burst_buffer_type: str | None
     cli_filter_plugins: Annotated[list[str] | None, Metadata(callback=CommaSepCallback)]
     cluster_name: str | None
-    communication_parameters: Annotated[dict[str, bool | int] | None, Metadata()]
+    communication_parameters: Annotated[
+        dict[str, bool | int] | None, Metadata(callback=CommaDictCallback)
+    ]
     complete_wait: int | None
     cpu_freq_def: str | None
     cpu_freq_governors: Annotated[list[str] | None, Metadata(callback=CommaSepCallback)]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR addresses issues #51 and #52 by setting the descriptor `communication_parameters`'s callback to `CommaDictCallback`, and fixing the logic used to handle `False` boolean values in `_make_dict_callback`.

No version bump is required here because I am planning on rolling these bug fix updates into the 1.1.1 release which introduces strict type checkin.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes #51
- Fixes #52

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a bugfix PR that makes no user-facing changes
