### PR TITLE
feat: atomic updates to files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "slurmutils"
-version = "1.1.2"
+version = "1.1.3"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 repository = "https://github.com/charmed-hpc/slurmutils"
 authors = ["Jason C. Nucciarone <nuccitheboss@ubuntu.com>"]

--- a/slurmutils/core/editor.py
+++ b/slurmutils/core/editor.py
@@ -43,8 +43,13 @@ class BaseEditor(Protocol[_TModel]):
         group: str | int | None = None,
     ) -> None:
         """Marshal a configuration model into a file."""
-        Path(file).write_text(self.dumps(obj) + "\n")
-        _set_file_permissions(file, mode=mode, user=user, group=group)
+        # Write to a temp file then atomically replace the target file.
+        dst = Path(file)
+        tmp = dst.with_suffix(dst.suffix + ".tmp")
+
+        tmp.write_text(self.dumps(obj) + "\n")
+        _set_file_permissions(tmp, mode=mode, user=user, group=group)
+        tmp.replace(dst)
 
     def dumps(self, obj: _TModel, /) -> str:
         """Marshal a configuration model into a `str`."""


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Modifies `BaseEditor.dump()` to write to a temporary file then replace the target, rather than writing in place.

For example, a write that was previously to `slurm.conf` is now performed to `slurm.conf.tmp`, which then replaces `slurm.conf` once the write is complete.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This provides atomic updates to files - Python's `Path.replace()` uses [rename](https://www.man7.org/linux/man-pages/man2/rename.2.html), which is atomic if source and target files are on the same file system. This has the benefit of ensuring another thread or process won't inadvertently read a partially written file.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

No documentation updates needed as this is not a user-facing change.