### PR TITLE
fix: handle `rebootprogram` with quote callback

### DIFF
--- a/slurmutils/slurm.py
+++ b/slurmutils/slurm.py
@@ -481,7 +481,7 @@ class SlurmConfig(Model):
         list[str] | None,
         Metadata(callback=CommaSepCallback),
     ]
-    reboot_program: str | None
+    reboot_program: Annotated[str | None, Metadata(callback=QuoteCallback)]
     reconfig_flags: Annotated[list[str] | None, Metadata(callback=CommaSepCallback)]
     requeue_exit: Annotated[list[str | int] | None, Metadata(callback=CommaSepCallback)]
     requeue_exit_hold: Annotated[list[str | int] | None, Metadata(callback=CommaSepCallback)]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR assigns `QuoteCallback` to the `rebootprogram` configuration option in the _slurm.conf_ data model.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes #61

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This is a bug fix PR that does not introduce any user-facing changes 