### PR TITLE
fix: use `MultilineCallback` for marshaling `include` directive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slurmutils"
-version = "1.1.5"
+version = "1.1.6"
 description = "Utilities and APIs for interfacing with the Slurm workload manager."
 authors = [{ name = "Jason C. Nucciarone", email = "nuccitheboss@ubuntu.com" }]
 requires-python = ">=3.10"

--- a/src/slurmutils/slurm.py
+++ b/src/slurmutils/slurm.py
@@ -376,7 +376,7 @@ class SlurmConfig(Model):
     health_check_node_state: Annotated[list[str] | None, Metadata(callback=CommaSepCallback)]
     health_check_program: str | None
     inactive_limit: int | None
-    include: Annotated[list[str] | None, Metadata(sep=" ", unique=False)]
+    include: Annotated[list[str] | None, Metadata(sep=" ", unique=False, callback=MultilineCallback)]
     interactive_step_options: str | None
     job_acct_gather_type: str | None
     job_acct_gather_frequency: Annotated[

--- a/tests/unit/models/test_slurm.py
+++ b/tests/unit/models/test_slurm.py
@@ -125,6 +125,8 @@ class TestSlurmConfig(TestCase):
             config.proctrack_type = "proctrack/linuxproc"
             config.plugin_dir.append("/snap/slurm/current/plugins")
             config.slurmctld_parameters = {"enable_configless": True}
+            config.include = ["slurm.conf.overrides", "slurm.conf.profiling"]
+
             new_node = Node(**config.nodes["juju-c9fc6f-2"].dict())
             new_node.node_name = "batch-0"
             del config.nodes["juju-c9fc6f-2"]
@@ -140,6 +142,7 @@ class TestSlurmConfig(TestCase):
             ["/usr/local/lib", "/usr/local/slurm/lib", "/snap/slurm/current/plugins"],
         )
         self.assertDictEqual(config.slurmctld_parameters, {"enable_configless": True})
+        self.assertListEqual(config.include, ["slurm.conf.overrides", "slurm.conf.profiling"])
         self.assertEqual(config.nodes["batch-0"].node_addr, "10.152.28.48")
 
         with slurmconfig.edit("/etc/slurm/slurm.conf") as config:

--- a/uv.lock
+++ b/uv.lock
@@ -389,7 +389,7 @@ wheels = [
 
 [[package]]
 name = "slurmutils"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR fixes how `include` directives are marshaled so that:

1. The incorrect marshaling does not cause `slurmctld` to raise an error when reading include directives in the _slurm.conf_ configuration file.
2. We can use additional _slurm.conf_ files for complex cluster configuration.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes #64

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

Non-user facing bugfix.