### PR TITLE
fix: add missing metricstype to schema and models

### DIFF
--- a/src/slurmutils/core/schema.py
+++ b/src/slurmutils/core/schema.py
@@ -978,6 +978,7 @@ SLURM_CONFIG_MODEL_SCHEMA = {
             "enum": ["mcs/none", "mcs/account", "mcs/group", "mcs/user", "mcs/label"],
         },
         "messagetimeout": {"type": "integer", "minimum": 0},
+        "metricstype": {"type": "string", "enum": ["metrics/openmetrics"]},
         "minjobage": {"type": "integer", "minimum": 0},
         "mpidefault": {"type": "string", "enum": ["pmi2", "pmix", "none"]},
         "mpiparams": {

--- a/src/slurmutils/slurm.py
+++ b/src/slurmutils/slurm.py
@@ -431,6 +431,7 @@ class SlurmConfig(Model):
     ]
     mcs_plugin: str | None
     message_timeout: int | None
+    metrics_type: str | None
     min_job_age: int | None
     mpi_default: str | None
     mpi_params: Annotated[

--- a/src/slurmutils/slurm.pyi
+++ b/src/slurmutils/slurm.pyi
@@ -259,6 +259,7 @@ class SlurmConfig(Model):
     mcs_parameters: dict[str, bool | list[str]] | None
     mcs_plugin: str | None
     message_timeout: int | None
+    metrics_type: str | None
     min_job_age: int | None
     mpi_default: str | None
     mpi_params: dict[str, bool | str] | None


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This patch adds `MetricsType` configuration parameter that is now available in the standard slurm configuration but it is not recognized by `slurmutils`.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)
fixes #67 


## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

