### PR TITLE
chore: migrate repo to the canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-** @charmed-hpc/python-reviewers
+** @canonical/hpc-code-reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Pre-submission checklist
+
+ * [ ] I read and followed the CONTRIBUTING guidelines.
+ * [ ] I have ensured that lint, typecheck, and unit tests complete successfully.
+
+[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)
+
+## Summary of changes
+
+[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)
+
+
+
+#### Related Issues, PRs, and Discussions
+
+[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)
+
+
+
+## Docs
+
+* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.
+
+[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)
+
+Or:
+
+* [ ] I confirm that this pull request requires no changes or additions to documentation.
+
+[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,11 @@ Before you start working on your contribution, please familiarize yourself with 
 HPC project's contributing guide]. After you've gone through the main contributing guide,
 you can use this guide for specific information on contributing to the `slurmutils` repository.
 
-Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat]
-or on [GitHub Discussions].
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat].
 
-[Charmed HPC project's contributing guide]: https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md
+[Charmed HPC project's contributing guide]: https://github.com/canonical/docs/blob/main/CONTRIBUTING.md
 [Ubuntu High-Performance Computing Matrix chat]: https://matrix.to/#/#hpc:ubuntu.com
-[GitHub Discussions]: https://github.com/orgs/charmed-hpc/discussions/categories/support
+
 
 ## Hacking on `slurmutils`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![PyPI - Version](https://img.shields.io/pypi/v/slurmutils)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/slurmutils)
-![GitHub License](https://img.shields.io/github/license/charmed-hpc/slurmutils)
+![GitHub License](https://img.shields.io/github/license/canonical/slurmutils)
 [![Matrix](https://img.shields.io/matrix/ubuntu-hpc%3Amatrix.org?logo=matrix&label=ubuntu-hpc)](https://matrix.to/#/#hpc:ubuntu.com)
 
 Utilities and APIs for interfacing with the Slurm workload manager.
@@ -202,8 +202,7 @@ with slurmdbdconfig.edit("/etc/slurm/slurmdbd.conf") as config:
 If you want to learn more about all the things you can do with slurmutils, 
 here are some further resources for you to explore:
 
-* [Open an issue](https://github.com/charmed-hpc/slurmutils/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
-* [Ask a question on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
+* [Open an issue](https://github.com/canonical/slurmutils/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
 
 ## 🛠️ Development
 
@@ -231,7 +230,6 @@ Here’s some links to help you get started with joining the community:
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Join the conversation on Matrix](https://matrix.to/#/#hpc:ubuntu.com)
 * [Get the latest news on Discourse](https://discourse.ubuntu.com/c/hpc/151)
-* [Ask and answer questions on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 
 ## 📋 License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The preferred way to report a security issue is through [GitHub Security Advisor
 [Privately reporting a security vulnerability][how-to-sec-vuln] for instructions on how to report a security vulnerability
 using GitHub's security advisory feature.
 
-[gsa]: https://github.com/charmed-hpc/slurmutils/security/advisories/new
+[gsa]: https://github.com/canonical/slurmutils/security/advisories/new
 [how-to-sec-vuln]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
 
 You may also send email to [security@ubuntu.com](mailto:security@ubuntu.com). Email may optionally be encrypted to OpenPGP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ dev = [
 ]
 
 [project.urls]
-repository = "https://github.com/charmed-hpc/slurmutils"
-issues = "https://github.com/charmed-hpc/slurmutils/issues"
+repository = "https://github.com/canonical/slurmutils"
+issues = "https://github.com/canonical/slurmutils/issues"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Migrate all our references to the charmed-hpc org to the canonical org equivalent.