### PR TITLE
chore: update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,14 @@ Before you start working on your contribution, please familiarize yourself with 
 HPC project's contributing guide]. After you've gone through the main contributing guide,
 you can use this guide for specific information on contributing to the `slurmutils` repository.
 
-Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat].
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat]
+or in the [High-Performance Computing category on the Ubuntu Discourse].
 
-[Charmed HPC project's contributing guide]: https://github.com/canonical/docs/blob/main/CONTRIBUTING.md
+[Charmed HPC project's contributing guide]: https://github.com/canonical/hpc-team/blob/main/CONTRIBUTING.md
 [Ubuntu High-Performance Computing Matrix chat]: https://matrix.to/#/#hpc:ubuntu.com
-
+[High-Performance Computing category on the Ubuntu Discourse]: https://discourse.ubuntu.com/c/project/hpc/151
 
 ## Hacking on `slurmutils`
-
 
 This repository uses [just](https://github.com/casey/just) and [uv](https://github.com/astral-sh/uv) for development
 which provide some useful commands that will help you while hacking on `slurmutils`:
@@ -92,4 +92,3 @@ and you make changes to that file in 2025, update the copyright year in the file
 ```text
 Copyright 2023-2025 Canonical Ltd.
 ```
-


### PR DESCRIPTION
Update the contributing guide to reference the Ubuntu Discourse and the hpc-team org guide.