### PR TITLE
chore: update README with Ubuntu Discourse links

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ If you want to learn more about all the things you can do with slurmutils,
 here are some further resources for you to explore:
 
 * [Open an issue](https://github.com/canonical/slurmutils/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
+* [Ask a question](https://discourse.ubuntu.com/c/project/hpc/151)
 
 ## 🛠️ Development
 
@@ -222,14 +223,14 @@ take a look at our [contributing guidelines](./CONTRIBUTING.md) for further deta
 ## 🤝 Project and community
 
 slurmutils is a project of the [Ubuntu High-Performance Computing community](https://ubuntu.com/community/governance/teams/hpc).
-Interested in contributing bug fixes, new editors, documentation, or feedback? Want to join the Ubuntu HPC community? You’ve come to the right place 🤩
+Interested in contributing bug fixes, new editors, documentation, or feedback? Want to join the Ubuntu HPC community? You've come to the right place 🤩
 
-Here’s some links to help you get started with joining the community:
+Here's some links to help you get started with joining the community:
 
 * [Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct)
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Join the conversation on Matrix](https://matrix.to/#/#hpc:ubuntu.com)
-* [Get the latest news on Discourse](https://discourse.ubuntu.com/c/hpc/151)
+* [Get the latest news or ask and answer questions on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151)
 
 ## 📋 License
 


### PR DESCRIPTION
Add Ubuntu Discourse links to the README.