### PR TITLE
feat: add package publishing and release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "pyproject.toml"
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
+  tag-and-release:
+    needs: ci
+    permissions:
+      contents: write
+    uses: canonical/hpc-team/.github/workflows/release-python-package.yaml@main
+
+  publish:
+    needs: [ci, tag-and-release]
+    uses: canonical/hpc-team/.github/workflows/publish-python-package.yaml@main
+    secrets:
+      PYPI_PUBLISH_TOKEN: ${{ secrets.PYPI_PUBLISH_TOKEN }}


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Add a GitHub Actions workflow that calls the traditional package publishing and release callable workflows from `canonical/hpc-team`. On push to `main` with a version bump in `pyproject.toml`, the workflow runs CI, creates a git tag and GitHub release, then builds and publishes the package to PyPI using Trusted Publishers (OIDC).

#### Related Issues, PRs, and Discussions

Closes HPCENG-876.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.